### PR TITLE
Plot all three sites and use checkboxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ rsconnect/
 
 # large data
 data/gsi_living_lab_data.csv
+app/data/gsi_living_lab_data.csv
+

--- a/app/R/0-theme_gsi.R
+++ b/app/R/0-theme_gsi.R
@@ -13,4 +13,4 @@ theme_gsi <- function() {
 #set it as the default theme for all plots.
 theme_set(theme_gsi())
 
-gsi_site_colors <- c("Old Main" = "red", "Gould Simpson" = "green", "Physics and Atmospheric Sciences" = "blue")
+gsi_site_colors <- c("Old Main" = "#AB0520", "Gould Simpson" = "#70B865", "Physics and Atmospheric Sciences" = "#1E5288")

--- a/app/R/0-theme_gsi.R
+++ b/app/R/0-theme_gsi.R
@@ -13,3 +13,4 @@ theme_gsi <- function() {
 #set it as the default theme for all plots.
 theme_set(theme_gsi())
 
+gsi_site_colors <- c("Old Main" = "red", "Gould Simpson" = "green", "Physics and Atmospheric Sciences" = "blue")

--- a/app/R/gsi_plot_airtemp.R
+++ b/app/R/gsi_plot_airtemp.R
@@ -12,6 +12,8 @@ gsi_plot_airtemp <- function(data) {
     geom_line() +
     #this makes the line go all the way to the edge of the plot.  I like this for timeseries
     scale_x_datetime(expand = c(0,0)) +
+    scale_color_manual(values = gsi_site_colors) + #defined in 0-theme_gsi.R
+    guides(color = FALSE) + #turn off legend
     labs(y = "Air Temp. (ºC)") +
     theme(axis.title.x = element_blank()) 
 }

--- a/app/R/gsi_plot_airtemp.R
+++ b/app/R/gsi_plot_airtemp.R
@@ -13,7 +13,7 @@ gsi_plot_airtemp <- function(data) {
     #this makes the line go all the way to the edge of the plot.  I like this for timeseries
     scale_x_datetime(expand = c(0,0)) +
     scale_color_manual(values = gsi_site_colors) + #defined in 0-theme_gsi.R
-    guides(color = FALSE) + #turn off legend
+    guides(color = "none") + #turn off legend
     labs(y = "Air Temp. (ºC)") +
     theme(axis.title.x = element_blank()) 
 }

--- a/app/R/gsi_plot_airtemp.R
+++ b/app/R/gsi_plot_airtemp.R
@@ -8,8 +8,8 @@ gsi_plot_airtemp <- function(data) {
     data |> 
     filter(str_starts(sensor, "ATM"))
   
-  ggplot(data_atm, aes(x = datetime, y = air_temperature.value)) +
-    geom_line(color = "darkred") +
+  ggplot(data_atm, aes(x = datetime, y = air_temperature.value, color = site)) +
+    geom_line() +
     #this makes the line go all the way to the edge of the plot.  I like this for timeseries
     scale_x_datetime(expand = c(0,0)) +
     labs(y = "Air Temp. (ºC)") +

--- a/app/R/gsi_plot_precip.R
+++ b/app/R/gsi_plot_precip.R
@@ -7,11 +7,10 @@ gsi_plot_precip <- function(data) {
     data |> 
     filter(str_starts(sensor, "ATM")) 
   
-  ggplot(data_atm, aes(x = datetime, y = precipitation.value)) +
-    geom_col(color = "blue", fill = "blue") +
+  ggplot(data_atm, aes(x = datetime, y = precipitation.value, fill = site, color = site)) +
+    geom_col(position = position_dodge(preserve = "single")) +
     scale_x_datetime(expand = c(0,0)) +
     labs(y = "Precipitation (mm)") +
     theme(axis.title.x = element_blank()) 
 }
-
 

--- a/app/R/gsi_plot_precip.R
+++ b/app/R/gsi_plot_precip.R
@@ -11,7 +11,7 @@ gsi_plot_precip <- function(data) {
     geom_col(position = position_dodge(preserve = "single")) +
     scale_x_datetime(expand = c(0,0)) +
     scale_color_manual(values = gsi_site_colors, aesthetics = c("fill", "color")) + #defined in 0-theme_gsi.R
-    guides(color = FALSE, fill = FALSE) + #turn off legend
+    guides(color = "none", fill = "none") + #turn off legend
     labs(y = "Precipitation (mm)") +
     theme(axis.title.x = element_blank()) 
 }

--- a/app/R/gsi_plot_precip.R
+++ b/app/R/gsi_plot_precip.R
@@ -10,6 +10,8 @@ gsi_plot_precip <- function(data) {
   ggplot(data_atm, aes(x = datetime, y = precipitation.value, fill = site, color = site)) +
     geom_col(position = position_dodge(preserve = "single")) +
     scale_x_datetime(expand = c(0,0)) +
+    scale_color_manual(values = gsi_site_colors, aesthetics = c("fill", "color")) + #defined in 0-theme_gsi.R
+    guides(color = FALSE, fill = FALSE) + #turn off legend
     labs(y = "Precipitation (mm)") +
     theme(axis.title.x = element_blank()) 
 }

--- a/app/R/gsi_plot_vpd.R
+++ b/app/R/gsi_plot_vpd.R
@@ -17,7 +17,7 @@ gsi_plot_vpd <- function(data) {
     #this makes the line go all the way to the edge of the plot.  I like this for timeseries
     scale_x_datetime(expand = c(0,0)) +
     scale_color_manual(values = gsi_site_colors) + #defined in 0-theme_gsi.R
-    guides(color = FALSE) + #turn off legend
+    guides(color = "none") + #turn off legend
     theme(axis.title.x = element_blank(), legend.position = "top") +
     labs(y = "Vapor Pressure / VPD (kPa)")
 }

--- a/app/R/gsi_plot_vpd.R
+++ b/app/R/gsi_plot_vpd.R
@@ -16,6 +16,8 @@ gsi_plot_vpd <- function(data) {
     geom_line(aes(y = vpd.value, linetype = "VPD"), alpha = 0.5, na.rm = TRUE) +
     #this makes the line go all the way to the edge of the plot.  I like this for timeseries
     scale_x_datetime(expand = c(0,0)) +
+    scale_color_manual(values = gsi_site_colors) + #defined in 0-theme_gsi.R
+    guides(color = FALSE) + #turn off legend
     theme(axis.title.x = element_blank(), legend.position = "top") +
     labs(y = "Vapor Pressure / VPD (kPa)")
 }

--- a/app/R/gsi_plot_vpd.R
+++ b/app/R/gsi_plot_vpd.R
@@ -8,14 +8,12 @@ gsi_plot_vpd <- function(data) {
     data |> 
     filter(str_starts(sensor, "ATM")) 
   
-  ggplot(data_atm, aes(x = datetime)) +
+  ggplot(data_atm, aes(x = datetime, color = site)) +
     #rather than map color to a column in the data or set it manually, we do a
     #third thing—set it to a character string *inside* of aes().  This is a
     #"trick" for creating a color legend
-    geom_line(aes(y = vapor_pressure.value, color = "VP"), alpha = 0.5, na.rm = TRUE) +
-    geom_line(aes(y = vpd.value, color = "VPD"), alpha = 0.5, na.rm = TRUE) +
-    #adjust colors manually
-    scale_color_manual(name = "", values = c("VP" = "blue", "VPD" = "darkgreen")) +
+    geom_line(aes(y = vapor_pressure.value, linetype = "VP"), alpha = 0.5, na.rm = TRUE) +
+    geom_line(aes(y = vpd.value, linetype = "VPD"), alpha = 0.5, na.rm = TRUE) +
     #this makes the line go all the way to the edge of the plot.  I like this for timeseries
     scale_x_datetime(expand = c(0,0)) +
     theme(axis.title.x = element_blank(), legend.position = "top") +

--- a/app/app.R
+++ b/app/app.R
@@ -31,10 +31,16 @@ ui <- page_navbar(
     paste("Data last updated ", 
           format(max(data_full$datetime, na.rm = TRUE),
                  "%Y/%m/%d %H:%M")), #TODO check that timezone is AZ and not UTC
-    selectInput(
+    # selectInput(
+    #   inputId = "site",
+    #   label = "Site",
+    #   choices = unique(data_full$site)
+    # ),
+    checkboxGroupInput(
       inputId = "site",
       label = "Site",
-      choices = unique(data_full$site)
+      choices = unique(data_full$site),
+      selected = unique(data_full$site)
     ),
     airDatepickerInput(
       inputId = "daterange",
@@ -90,7 +96,7 @@ ui <- page_navbar(
 server <- function(input, output, session) {
   data_filtered <- reactive({
     data_full |> 
-      filter(site == input$site) |> 
+      filter(site %in% input$site) |> 
       filter(datetime >= input$daterange[1], datetime <= input$daterange[2])
   })
   

--- a/app/app.R
+++ b/app/app.R
@@ -5,6 +5,7 @@ library(bslib)
 library(bsicons)
 library(shinyWidgets)
 
+
 library(tidyverse)
 library(boxr)
 library(glue)
@@ -22,24 +23,27 @@ data_full <-
   right_join(site_info) |> 
   mutate(datetime = with_tz(datetime, "America/Phoenix"))
 
+site_checkbox_names <-
+  map2(names(gsi_site_colors), gsi_site_colors, \(x, y) {
+    HTML(paste(bs_icon("circle-fill", color = y), x))
+  })
+
 # UI ----------------------------------------------------------------------
 ui <- page_navbar(
   title = "GSI Living Lab",
   # fillable = FALSE, # make scrollable.  Try with and without this
   sidebar = sidebar(
+    open = "always", #I think this is necessary if the site legend is combined with the checkboxes.  Might make the dashboard look bad on mobile.
+    
     # This could be a value_box instead of just plain text
     paste("Data last updated ", 
           format(max(data_full$datetime, na.rm = TRUE),
                  "%Y/%m/%d %H:%M")), #TODO check that timezone is AZ and not UTC
-    # selectInput(
-    #   inputId = "site",
-    #   label = "Site",
-    #   choices = unique(data_full$site)
-    # ),
     checkboxGroupInput(
       inputId = "site",
       label = "Site",
-      choices = unique(data_full$site),
+      choiceValues = unique(data_full$site),
+      choiceNames = site_checkbox_names,
       selected = unique(data_full$site)
     ),
     airDatepickerInput(

--- a/app/app.R
+++ b/app/app.R
@@ -61,6 +61,7 @@ ui <- page_navbar(
   ),
   nav_panel(
     "Atmospheric",
+    p(HTML(glue::glue_collapse(site_checkbox_names, sep = " | "))),
     card(
       full_screen = TRUE,
       plotOutput("plot_airtemp")


### PR DESCRIPTION
This modifies the dashboard to use checkboxes instead of a drop-down menu to select sites.  In the plots, site is mapped to color/fill aesthetics.

There are two options for the color legend: at the top of the three cards or integrated with the checkboxes.  I don't think we need both, but I'm not sure which one is best.
![Screenshot 2023-12-14 at 12 03 38 PM](https://github.com/UArizonaGSICampusLivingLab/gsi-dashboard/assets/25404783/3ba458e7-c02d-494a-be70-87dadfa2f271)
