### PR TITLE
Separate date picker for monthly soil data tab

### DIFF
--- a/app/R/gsi_plot_soil.R
+++ b/app/R/gsi_plot_soil.R
@@ -28,7 +28,7 @@ gsi_plot_soil <- function(data, yvar) {
     scale_linetype_manual(values = c("y" = 1, "n" = 2)) +
     guides(color = "none") +
     theme(axis.title.x.bottom = element_blank()) +
-    facet_grid(depth~site, labeller = label_both)
+    facet_grid(depth~site)
   
   # Add line only if more than one month.  Otherwise this errors.
   if (length(unique(plot_data$month_num)) > 1) {

--- a/app/app.R
+++ b/app/app.R
@@ -109,16 +109,16 @@ ui <- page_navbar(
     htmlOutput("legend3"),
   ),
   
-  nav_panel(
-    "value box demo", 
-    #TODO: try putting these in sidebar
-    layout_columns(
-      height = "20%",
-      uiOutput("stat_airtemp"),
-      uiOutput("stat_soiltemp"),
-      uiOutput("stat_precip")
-    )
-  ),
+  # nav_panel(
+  #   "value box demo", 
+  #   #TODO: try putting these in sidebar
+  #   layout_columns(
+  #     height = "20%",
+  #     uiOutput("stat_airtemp"),
+  #     uiOutput("stat_soiltemp"),
+  #     uiOutput("stat_precip")
+  #   )
+  # ),
 )
 
 
@@ -173,62 +173,62 @@ server <- function(input, output, session) {
   })
   
   ##  Value boxes -------
-  output$stat_airtemp <- renderUI({
-    airtemp <- data_filtered()$air_temperature.value
-    
-    airtemp_vals <- 
-      c(
-        max(airtemp, na.rm = TRUE),
-        mean(airtemp, na.rm = TRUE),
-        min(airtemp, na.rm = TRUE)
-      ) |> 
-      round(2)
-    
-    value_box(
-      title = "Air Temperature",
-      value =  HTML(glue("
-           H: {airtemp_vals[1]} ºC<br>
-           M: {airtemp_vals[2]} ºC<br>
-           L: {airtemp_vals[3]} ºC
-           ")),
-      showcase = bs_icon("thermometer")
-    )
-  })
-  
-  output$stat_soiltemp <- renderUI({
-    soiltemp <- data_filtered()$soil_temperature.value
-    soiltemp_vals <- 
-      c(
-        max(soiltemp, na.rm = TRUE),
-        mean(soiltemp, na.rm = TRUE),
-        min(soiltemp, na.rm = TRUE)
-      ) |> 
-      round(2)
-    value_box(
-      title = "Soil Temperature",
-      value =  HTML(glue("
-           H: {soiltemp_vals[1]} ºC<br>
-           M: {soiltemp_vals[2]} ºC<br>
-           L: {soiltemp_vals[3]} ºC
-           ")),
-      showcase = bs_icon("thermometer")
-    )
-  })
-  
-  output$stat_precip<- renderUI({
-    
-    precip_total <- 
-      data_filtered()$precipitation.value |> 
-      sum(na.rm = TRUE) |> 
-      round(1)
-    
-    value_box(
-      title = "Total Precipitation",
-      #TODO: check that units are correct
-      value = paste(precip_total, "mm"),
-      showcase = bs_icon("cloud-rain")
-    )
-  })
+  # output$stat_airtemp <- renderUI({
+  #   airtemp <- data_filtered()$air_temperature.value
+  #   
+  #   airtemp_vals <- 
+  #     c(
+  #       max(airtemp, na.rm = TRUE),
+  #       mean(airtemp, na.rm = TRUE),
+  #       min(airtemp, na.rm = TRUE)
+  #     ) |> 
+  #     round(2)
+  #   
+  #   value_box(
+  #     title = "Air Temperature",
+  #     value =  HTML(glue("
+  #          H: {airtemp_vals[1]} ºC<br>
+  #          M: {airtemp_vals[2]} ºC<br>
+  #          L: {airtemp_vals[3]} ºC
+  #          ")),
+  #     showcase = bs_icon("thermometer")
+  #   )
+  # })
+  # 
+  # output$stat_soiltemp <- renderUI({
+  #   soiltemp <- data_filtered()$soil_temperature.value
+  #   soiltemp_vals <- 
+  #     c(
+  #       max(soiltemp, na.rm = TRUE),
+  #       mean(soiltemp, na.rm = TRUE),
+  #       min(soiltemp, na.rm = TRUE)
+  #     ) |> 
+  #     round(2)
+  #   value_box(
+  #     title = "Soil Temperature",
+  #     value =  HTML(glue("
+  #          H: {soiltemp_vals[1]} ºC<br>
+  #          M: {soiltemp_vals[2]} ºC<br>
+  #          L: {soiltemp_vals[3]} ºC
+  #          ")),
+  #     showcase = bs_icon("thermometer")
+  #   )
+  # })
+  # 
+  # output$stat_precip<- renderUI({
+  #   
+  #   precip_total <- 
+  #     data_filtered()$precipitation.value |> 
+  #     sum(na.rm = TRUE) |> 
+  #     round(1)
+  #   
+  #   value_box(
+  #     title = "Total Precipitation",
+  #     #TODO: check that units are correct
+  #     value = paste(precip_total, "mm"),
+  #     showcase = bs_icon("cloud-rain")
+  #   )
+  # })
 }
 
 shinyApp(ui, server)

--- a/app/app.R
+++ b/app/app.R
@@ -60,8 +60,8 @@ ui <- page_navbar(
         inputId = "monthrange",
         label = "Date Range",
         range = TRUE,
-        # Default date range
-        value = c(Sys.Date() - 365, Sys.Date()),
+        # Default date range is a year ago or to the earliest day of data, whichever is more recent
+        value = c(max(Sys.Date() - 365, as.Date("2023-06-05")), Sys.Date()), 
         dateFormat = "MM/dd/yy",
         maxDate = Sys.Date(),
         minDate = "2023-06-05",
@@ -71,7 +71,6 @@ ui <- page_navbar(
         update_on = "close"
       )
     )
-    
   ),
   nav_panel(
     "Atmospheric",


### PR DESCRIPTION
Uses `shiny::conditionalPanel()` to show a different datepicker where only months are shown on the Soil tab.  Note: this means that the datepickers in the two tabs are no longer "connected"—they can have different date ranges selected. 

I also changed the default date selections to be the previous 7 days for the Atmosphere tab and the previous year (or since the beginning of data collection) for the Soil tab.