### PR TITLE
Daily summary

### DIFF
--- a/app/R/gsi_plot_airtemp.R
+++ b/app/R/gsi_plot_airtemp.R
@@ -44,29 +44,3 @@ gsi_plot_airtemp <- function(data, daily = FALSE) {
     labs(y = "Air Temp. (ºC)") +
     theme(axis.title.x = element_blank())   
 }
-
-
-# An alternative that summarizes the hourly data to daily with daily mean, low, and high
-#' `data`: the dataset already filtered to a single site and a date range
-gsi_plot_airtemp_daily <- function(data) {
-  data_atm <- 
-    data |> 
-    filter(str_starts(sensor, "ATM"))
-  
-  data_airtemp <- 
-    data_atm |> 
-    mutate(date = date(datetime)) |> 
-    group_by(date) |> 
-    summarize(
-      airtemp_mean = mean(air_temperature.value, na.rm = TRUE),
-      airtemp_low = min(air_temperature.value, na.rm = TRUE),
-      airtemp_high = max(air_temperature.value, na.rm = TRUE)
-    )
-  
-  ggplot(data_airtemp, aes(x = date)) +
-    geom_line(aes(y = airtemp_mean), color = "darkred") +
-    geom_ribbon(aes(ymin = airtemp_low, ymax = airtemp_high), fill = "darkred", alpha = 0.4) +
-    scale_x_date(expand = c(0,0)) +
-    labs(y = "Air Temp. (ºC)") +
-    theme(axis.title.x = element_blank())
-}

--- a/app/R/gsi_plot_airtemp.R
+++ b/app/R/gsi_plot_airtemp.R
@@ -2,20 +2,47 @@ library(dplyr)
 library(ggplot2)
 
 #' `data`: the dataset already filtered to a single site and a date range
-gsi_plot_airtemp <- function(data) {
+#' `daily`: plot a daily summary instead of hourly data
+gsi_plot_airtemp <- function(data, daily = FALSE) {
   
   data_atm <- 
     data |> 
     filter(str_starts(sensor, "ATM"))
   
-  ggplot(data_atm, aes(x = datetime, y = air_temperature.value, color = site)) +
-    geom_line(alpha = 0.5, linewidth = 0.65) +
+  if (isTRUE(daily)) {
+    data_atm <- 
+      data_atm |> 
+      mutate(date = floor_date(datetime, "day")) |> 
+      dplyr::summarize(
+        airtemp_mean = mean(air_temperature.value, na.rm = TRUE),
+        airtemp_low = min(air_temperature.value, na.rm = TRUE),
+        airtemp_high = max(air_temperature.value, na.rm = TRUE),
+        .by = c(site, date)
+      ) |> 
+      #becaue min(c(NA, NA, NA), na.rm = TRUE) results in Inf, we need to replace these with regular NAs for better plotting
+      mutate(across(starts_with("airtemp_"), \(x) if_else(!is.finite(x), NA, x)))
+  }
+  
+  
+  if (isTRUE(daily)) {
+    p <- 
+      ggplot(data_atm, aes(x = date, y = airtemp_mean, ymin = airtemp_low, ymax = airtemp_high)) +
+      geom_line(aes(color = site), linewidth = 0.65) +
+      geom_ribbon(aes(fill = site), alpha = 0.4)
+    
+  } else {
+    p <-
+      ggplot(data_atm, aes(x = datetime, y = air_temperature.value, color = site)) +
+      geom_line(alpha = 0.5, linewidth = 0.65) 
+  }
+
+  p +
     #this makes the line go all the way to the edge of the plot.  I like this for timeseries
     scale_x_datetime(expand = c(0,0)) +
-    scale_color_manual(values = gsi_site_colors) + #defined in 0-theme_gsi.R
-    guides(color = "none") + #turn off legend
+    scale_color_manual(values = gsi_site_colors, aesthetics = c("fill", "color")) + #defined in 0-theme_gsi.R
+    guides(color = "none", fill = "none") + #turn off legend
     labs(y = "Air Temp. (ºC)") +
-    theme(axis.title.x = element_blank()) 
+    theme(axis.title.x = element_blank())   
 }
 
 

--- a/app/R/gsi_plot_precip.R
+++ b/app/R/gsi_plot_precip.R
@@ -2,10 +2,23 @@ library(dplyr)
 library(ggplot2)
 
 #' `data`: the dataset already filtered to a single site and a date range
-gsi_plot_precip <- function(data) {
+#' `daily`: plot daily summary instead of hourly data
+gsi_plot_precip <- function(data, daily = FALSE) {
   data_atm <- 
     data |> 
     filter(str_starts(sensor, "ATM")) 
+  
+  if (isTRUE(daily)) {
+    data_atm <-
+      data_atm |> 
+      mutate(datetime = floor_date(datetime, "day")) |> 
+      dplyr::summarise(
+        precipitation.value = sum(precipitation.value, na.rm = TRUE),
+        .by = c(site, datetime)
+      ) |> 
+      #becaue sum(c(NA, NA, NA), na.rm = TRUE) results in Inf, we need to replace these with regular NAs for better plotting
+      mutate(precipitation.value = if_else(!is.finite(precipitation.value), NA, precipitation.value))
+  }
   
   ggplot(data_atm, aes(x = datetime, y = precipitation.value, fill = site, color = site)) +
     geom_col(position = position_dodge2(padding = 0.2, preserve = "total")) +

--- a/app/R/gsi_plot_vpd.R
+++ b/app/R/gsi_plot_vpd.R
@@ -2,11 +2,24 @@ library(dplyr)
 library(ggplot2)
 
 #' `data`: the dataset already filtered to a single site and a date range
-gsi_plot_vpd <- function(data) {
+#' `daily`: display a daily summary instead of hourly data
+gsi_plot_vpd <- function(data, daily = FALSE) {
   #use just atmospheric sensor data for this plot
   data_atm <- 
     data |> 
     filter(str_starts(sensor, "ATM")) 
+  
+  if (isTRUE(daily)) {
+    data_atm <-
+      data_atm |> 
+      mutate(datetime = floor_date(datetime, "day")) |> 
+      dplyr::summarize(
+        across(c(vapor_pressure.value, vpd.value), \(x) mean(x, na.rm = TRUE)),
+        .by = c(site, datetime)
+      ) |> 
+      #because mean(c(NA, NA, NA), na.rm = TRUE) results in Inf, we need to replace these with regular NAs for better plotting
+      mutate(across(c(vapor_pressure.value, vpd.value), \(x) if_else(!is.finite(x), NA, x)))
+  }
   
   ggplot(data_atm, aes(x = datetime, color = site)) +
     #rather than map color to a column in the data or set it manually, we do a

--- a/app/app.R
+++ b/app/app.R
@@ -146,19 +146,16 @@ server <- function(input, output, session) {
   })
   
   ## Plots --------
-  output$plot_vp <- renderPlot({
-    gsi_plot_vpd(data_filtered_atm())
-  })
-  
   output$plot_airtemp <- renderPlot({
     gsi_plot_airtemp(data_filtered_atm(), daily = input$daily)
-    # daily summarized alternative:
-    # gsi_plot_airtemp_daily(data_filtered())
-    # Idea: hook this up to a switch in the card so you can switch between hourly and daily views?
   })
   
   output$plot_precip <- renderPlot({
     gsi_plot_precip(data_filtered_atm(), daily = input$daily)
+  })
+  
+  output$plot_vp <- renderPlot({
+    gsi_plot_vpd(data_filtered_atm(), daily = input$daily)
   })
   
   output$plot_soil_temp <- renderPlot({

--- a/app/app.R
+++ b/app/app.R
@@ -52,6 +52,10 @@ ui <- page_navbar(
         minDate = "2023-06-05",
         addon = "none",
         update_on = "close"
+      ),
+      conditionalPanel(
+        "input.navbar == 'Atmospheric'",
+        input_switch("daily", "Daily Summary")
       )
     ),
     conditionalPanel(
@@ -147,14 +151,14 @@ server <- function(input, output, session) {
   })
   
   output$plot_airtemp <- renderPlot({
-    gsi_plot_airtemp(data_filtered_atm())
+    gsi_plot_airtemp(data_filtered_atm(), daily = input$daily)
     # daily summarized alternative:
     # gsi_plot_airtemp_daily(data_filtered())
     # Idea: hook this up to a switch in the card so you can switch between hourly and daily views?
   })
   
   output$plot_precip <- renderPlot({
-    gsi_plot_precip(data_filtered_atm())
+    gsi_plot_precip(data_filtered_atm(), daily = input$daily)
   })
   
   output$plot_soil_temp <- renderPlot({

--- a/renv.lock
+++ b/renv.lock
@@ -31,6 +31,44 @@
       ],
       "Hash": "b2866e62bab9378c3cc9476a1954226b"
     },
+    "Formula": {
+      "Package": "Formula",
+      "Version": "1.2-5",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "stats"
+      ],
+      "Hash": "7a29697b75e027767a53fde6c903eca7"
+    },
+    "Hmisc": {
+      "Package": "Hmisc",
+      "Version": "5.1-1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "Formula",
+        "base64enc",
+        "cluster",
+        "colorspace",
+        "data.table",
+        "foreign",
+        "ggplot2",
+        "grid",
+        "gridExtra",
+        "gtable",
+        "htmlTable",
+        "htmltools",
+        "knitr",
+        "methods",
+        "nnet",
+        "rmarkdown",
+        "rpart",
+        "viridis"
+      ],
+      "Hash": "27c7750992bc511728e2f9ebd2911199"
+    },
     "MASS": {
       "Package": "MASS",
       "Version": "7.3-60",
@@ -361,6 +399,18 @@
       ],
       "Hash": "f61dbaec772ccd2e17705c1e872e9e7c"
     },
+    "checkmate": {
+      "Package": "checkmate",
+      "Version": "2.3.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "backports",
+        "utils"
+      ],
+      "Hash": "c01cab1cb0f9125211a6fc99d540e315"
+    },
     "chron": {
       "Package": "chron",
       "Version": "2.3-61",
@@ -393,6 +443,20 @@
         "utils"
       ],
       "Hash": "3f038e5ac7f41d4ac41ce658c85e3042"
+    },
+    "cluster": {
+      "Package": "cluster",
+      "Version": "2.1.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "grDevices",
+        "graphics",
+        "stats",
+        "utils"
+      ],
+      "Hash": "5edbbabab6ce0bf7900a74fd4358628e"
     },
     "colorspace": {
       "Package": "colorspace",
@@ -787,6 +851,20 @@
       ],
       "Hash": "d6db1667059d027da730decdc214b959"
     },
+    "gridExtra": {
+      "Package": "gridExtra",
+      "Version": "2.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "grDevices",
+        "graphics",
+        "grid",
+        "gtable",
+        "utils"
+      ],
+      "Hash": "7d7f283939f563670a697165b2cf5560"
+    },
     "gtable": {
       "Package": "gtable",
       "Version": "0.3.4",
@@ -823,6 +901,16 @@
       ],
       "Hash": "9b302fe352f9cfc5dcf0a4139af3a565"
     },
+    "here": {
+      "Package": "here",
+      "Version": "1.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "rprojroot"
+      ],
+      "Hash": "24b224366f9c2e7534d2344d10d59211"
+    },
     "highr": {
       "Package": "highr",
       "Version": "0.10",
@@ -847,6 +935,24 @@
         "vctrs"
       ],
       "Hash": "b59377caa7ed00fa41808342002138f9"
+    },
+    "htmlTable": {
+      "Package": "htmlTable",
+      "Version": "2.4.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "checkmate",
+        "htmltools",
+        "htmlwidgets",
+        "knitr",
+        "magrittr",
+        "methods",
+        "rstudioapi",
+        "stringr"
+      ],
+      "Hash": "0164d8cade33fac2190703da7e6e3241"
     },
     "htmltools": {
       "Package": "htmltools",
@@ -1161,6 +1267,18 @@
         "utils"
       ],
       "Hash": "0984ce8da8da9ead8643c5cbbb60f83e"
+    },
+    "nnet": {
+      "Package": "nnet",
+      "Version": "7.3-19",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "stats",
+        "utils"
+      ],
+      "Hash": "2c797b46eea7fb58ede195bc0b1f1138"
     },
     "openssl": {
       "Package": "openssl",
@@ -1504,6 +1622,29 @@
         "yaml"
       ],
       "Hash": "d65e35823c817f09f4de424fcdfa812a"
+    },
+    "rpart": {
+      "Package": "rpart",
+      "Version": "4.1.19",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "grDevices",
+        "graphics",
+        "stats"
+      ],
+      "Hash": "b3c892a81783376cc2204af0f5805a80"
+    },
+    "rprojroot": {
+      "Package": "rprojroot",
+      "Version": "2.0.4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "4c8415e0ec1e29f3f4f6fc108bef0144"
     },
     "rsconnect": {
       "Package": "rsconnect",
@@ -1896,6 +2037,19 @@
         "rlang"
       ],
       "Hash": "266c1ca411266ba8f365fcc726444b87"
+    },
+    "viridis": {
+      "Package": "viridis",
+      "Version": "0.6.4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "ggplot2",
+        "gridExtra",
+        "viridisLite"
+      ],
+      "Hash": "80cd127bc8c9d3d9f0904ead9a9102f1"
     },
     "viridisLite": {
       "Package": "viridisLite",


### PR DESCRIPTION
Addresses #14 by adding a "daily summary" switch to the atmospheric tab sidebar.  Toggling this switches the temperature line plot to show daily means (lines) and range (ribbon), switches the precip bar graph from hourly totals to daily totals, and switches the VP/VPD plot to a line plot of daily means.  I decided not to do the range ribbon for the vp/vpd plot since it's already a fairly busy plot, but could add it to this plot also.