### PR TITLE
bug fix for pinched ribbons

### DIFF
--- a/app/R/gsi_plot_airtemp.R
+++ b/app/R/gsi_plot_airtemp.R
@@ -12,7 +12,7 @@ gsi_plot_airtemp <- function(data, daily = FALSE) {
   if (isTRUE(daily)) {
     data_atm <- 
       data_atm |> 
-      mutate(date = floor_date(datetime, "day")) |> 
+      mutate(date = floor_date(datetime, "day")) |> #TODO BUG: last day always has range of 0º
       dplyr::summarize(
         airtemp_mean = mean(air_temperature.value, na.rm = TRUE),
         airtemp_low = min(air_temperature.value, na.rm = TRUE),
@@ -44,3 +44,4 @@ gsi_plot_airtemp <- function(data, daily = FALSE) {
     labs(y = "Air Temp. (ºC)") +
     theme(axis.title.x = element_blank())   
 }
+

--- a/app/R/gsi_plot_airtemp.R
+++ b/app/R/gsi_plot_airtemp.R
@@ -12,7 +12,7 @@ gsi_plot_airtemp <- function(data, daily = FALSE) {
   if (isTRUE(daily)) {
     data_atm <- 
       data_atm |> 
-      mutate(date = floor_date(datetime, "day")) |> #TODO BUG: last day always has range of 0º
+      mutate(date = floor_date(datetime, "day")) |>
       dplyr::summarize(
         airtemp_mean = mean(air_temperature.value, na.rm = TRUE),
         airtemp_low = min(air_temperature.value, na.rm = TRUE),

--- a/app/app.R
+++ b/app/app.R
@@ -136,12 +136,14 @@ server <- function(input, output, session) {
   data_filtered_atm <- reactive({
     data_full |> 
       filter(site %in% input$site) |> 
-      filter(datetime >= input$daterange[1], datetime <= input$daterange[2])
+      filter(date(datetime) >= input$daterange[1],
+             date(datetime) <= input$daterange[2])
   })
   data_filtered_soil <- reactive({
     data_full |> 
       filter(site %in% input$site) |> 
-      filter(datetime >= input$monthrange[1], datetime <= input$monthrange[2])
+      filter(date(datetime) >= input$monthrange[1],
+             date(datetime) <= input$monthrange[2])
   })
   ## Legend -------
   #can't re-use output objects, so make one for each tab


### PR DESCRIPTION
In the daily view of airtemp, the ribbons showing temp range were always constricted to zero at the last date.  This is because of how datetimes were being filtered by dates.  Now fixed in this PR.